### PR TITLE
Fix missing option on typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -16,8 +16,8 @@ export declare type Config = {
 };
 export declare function getOpts(
 	input: any[],
-	optdef: string | { [key: string]: string },
-	config: Config
+	optdef?: string | { [key: string]: string },
+	config?: Config
 ): Options;
 
 export default getOpts;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,6 @@
 export declare type Options = { options: any; argv: string[] };
 export declare type Config = {
-	noAliasPropagation?: boolean;
+	noAliasPropagation?: boolean | 'first-only';
 	noCamelCase?: boolean;
 	noBundling?: boolean;
 	ignoreEquals?: boolean;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,23 +1,34 @@
-export declare type Options = { options: any; argv: string[] };
-export declare type Config = {
-	noAliasPropagation?: boolean | "first-only";
-	noCamelCase?: boolean;
-	noBundling?: boolean;
-	ignoreEquals?: boolean;
-	duplicates?:
-		| "use-first"
-		| "use-last"
-		| "limit-first"
-		| "limit-last"
-		| "error"
-		| "append"
-		| "stack"
-		| "stack-values";
-};
-export declare function getOpts(
+// Import the function like 
+// import getOpts  = require('get-options');
+// If you need the types you can import them like normal
+// import { Options } from 'get-options';
+
+/**
+ * Extract command-line options from a list of strings.
+ */
+declare function getOpts(
 	input: any[],
 	optdef?: string | { [key: string]: string },
-	config?: Config
-): Options;
+	config?: getOpts.Config
+): getOpts.Options;
 
-export default getOpts;
+export = getOpts;
+
+declare namespace getOpts {
+	export type Options = { options: any; argv: string[] };
+	export type Config = {
+		noAliasPropagation?: boolean |  "first-only";
+		noCamelCase?: boolean;
+		noBundling?: boolean;
+		ignoreEquals?: boolean;
+		duplicates?:
+			| "use-first"
+			| "use-last"
+			| "limit-first"
+			| "limit-last"
+			| "error"
+			| "append"
+			| "stack"
+			| "stack-values";
+	};
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,23 @@
+export declare type Options = { options: any; argv: string[] };
+export declare type Config = {
+	noAliasPropagation?: boolean;
+	noCamelCase?: boolean;
+	noBundling?: boolean;
+	ignoreEquals?: boolean;
+	duplicates?:
+		| 'use-first'
+		| 'use-last'
+		| 'limit-first'
+		| 'limit-last'
+		| 'error'
+		| 'append'
+		| 'stack'
+		| 'stack-values';
+};
+export declare function getOpts(
+	input: any[],
+	optdef: string | { [key: string]: string },
+	config: Config
+): Options;
+
+export default getOpts;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,18 +1,18 @@
 export declare type Options = { options: any; argv: string[] };
 export declare type Config = {
-	noAliasPropagation?: boolean | 'first-only';
+	noAliasPropagation?: boolean | "first-only";
 	noCamelCase?: boolean;
 	noBundling?: boolean;
 	ignoreEquals?: boolean;
 	duplicates?:
-		| 'use-first'
-		| 'use-last'
-		| 'limit-first'
-		| 'limit-last'
-		| 'error'
-		| 'append'
-		| 'stack'
-		| 'stack-values';
+		| "use-first"
+		| "use-last"
+		| "limit-first"
+		| "limit-last"
+		| "error"
+		| "append"
+		| "stack"
+		| "stack-values";
 };
 export declare function getOpts(
 	input: any[],

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
 	"license": "ISC",
 	"engines": { "node": ">=6.0.0" },
 	"files": ["index.js"],
+	"typings": "index.d.ts",
 	"dependencies": {},
 	"devDependencies": {
 		"mocha": "*",


### PR DESCRIPTION
Fixed typings on missing option

```js
noAliasPropagation?: boolean | 'first-only';
```